### PR TITLE
Fix JSON decode when incoming value is not a string

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -25,7 +25,9 @@ class Loader
 
         // JSON decode the meta query variable
         add_filter ('rest_query_var-meta_query', function($value) {
-          return json_decode($value, true);;
+            return is_string($value)
+                ? json_decode($value, true) ?: $value
+                : $value;
         });
 
         return true;


### PR DESCRIPTION
There are cases where this callback receives a value that is already an array, or otherwise not a JSON encoded string. The value should be returned as-is without trying to decoded it again.