### PR TITLE
Fix "too few arguments" post title error in PHP 7

### DIFF
--- a/src/Post.php
+++ b/src/Post.php
@@ -2057,7 +2057,7 @@ class Post extends Base
      */
     public function getTheTitle()
     {
-        return apply_filters('the_title', $this->get('post_title'));
+        return apply_filters('the_title', $this->get('post_title'), $this->get('ID'));
     }
 
 


### PR DESCRIPTION
Applying `the_title` filter without providing the post ID throws a fatal error in PHP 7. For some reason, I didn't run across this until activating WooCommerce, but `apply_filters('the_title', ...` in the WP source code always includes the post ID as an argument.